### PR TITLE
Fix #412 animation stops when ui block

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -73,10 +73,12 @@ class ContainerView: RCTView {
     
     
     func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime, completion: LottieCompletionBlock? = nil) {
+        animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completion);
     }
     
     func play(completion: LottieCompletionBlock? = nil) {
+        animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(completion: completion)
     }
     


### PR DESCRIPTION
Fix AnimationUIblock on scroll or when mounting and unmounting components in ios